### PR TITLE
Add computer vision input size

### DIFF
--- a/yoonit-camera/src/main/java/ai/cyberlabs/yoonit/camera/ComputerVision.kt
+++ b/yoonit-camera/src/main/java/ai/cyberlabs/yoonit/camera/ComputerVision.kt
@@ -1,18 +1,15 @@
 package ai.cyberlabs.yoonit.camera
 
 import ai.cyberlabs.yoonit.camera.models.CaptureOptions
+import android.util.Size
 import java.io.File
 
 class ComputerVision {
+
     /**
      * Enable/disable computer vision usage.
-     *
-     * @param enable The indicator to enable/disable computer vision usage.
      * Default value is `false`.
      */
-    fun setComputerVision(enable: Boolean) {
-        CaptureOptions.computerVision.enable = enable
-    }
     var enable: Boolean = CaptureOptions.computerVision.enable
         set(value) {
             CaptureOptions.computerVision.enable = value
@@ -21,20 +18,8 @@ class ComputerVision {
 
     /**
      * Set the computer vision model paths to load.
-     *
-     * @param modelPaths The computer vision absolute model file path array list.
      * Default value is an empty array.
      */
-    fun setComputerVisionLoadModels(modelPaths: ArrayList<String>) {
-        modelPaths.forEach {
-                modelPath ->
-            if (!File(modelPath).exists()) {
-                throw IllegalArgumentException("${KeyError.INVALID_COMPUTER_VISION_MODEL_PATHS}: $modelPath")
-            }
-        }
-
-        CaptureOptions.computerVision.paths = modelPaths
-    }
     var modelPaths: ArrayList<String> = CaptureOptions.computerVision.paths
         set(value) {
             value.forEach {
@@ -48,12 +33,15 @@ class ComputerVision {
             field = value
         }
 
+    var inputSize: Size = CaptureOptions.computerVision.inputSize
+        set(value) {
+            CaptureOptions.computerVision.inputSize = value
+            field = value
+        }
+
     /**
      * Clear loaded computer vision models.
      */
-    fun computerVisionClearModels() {
-        CaptureOptions.computerVision.clear()
-    }
     fun clear() {
         CaptureOptions.computerVision.clear()
     }

--- a/yoonit-camera/src/main/java/ai/cyberlabs/yoonit/camera/models/ComputerVision.kt
+++ b/yoonit-camera/src/main/java/ai/cyberlabs/yoonit/camera/models/ComputerVision.kt
@@ -11,6 +11,7 @@
 
 package ai.cyberlabs.yoonit.camera.models
 
+import android.util.Size
 import org.pytorch.Module
 
 /**
@@ -20,6 +21,8 @@ class ComputerVision {
 
     //  Enable or disable computer vision models usage when capture images.
     var enable: Boolean = false
+
+    var inputSize: Size = Size(0, 0)
 
     // Computer vision models map.
     // Key is the name of the file and the value is the model loaded.


### PR DESCRIPTION
## 💥 Breaking Changes

| Deprecated                                   | New
| -                                                     | -
| setComputerVision                      | ComputerVision.enable
| setComputerVisionLoadModels | ComputerVision.modelPaths
| computerVisionClearModels      | ComputerVision.clear

## ✨ New Feature

* Computer Vision Input Size of the Image.

| Variable   | Type | Default Value | Description
| -               | -        | -                     | -
| ComputerVision.inputSize | `Size`  | `(0, 0)`              | Image Input Size to use in the loaded computer vision models.
| ComputerVision.enable | `Boolean`  | `false`              | Enable/disable computer vision usage.
| ComputerVision.modelPaths | `ArrayList<String>`  | `[]`              | Set the computer vision model paths.

| Function | Input Type | Valid Values | Default Value | Description
| -        |  -          | -            | -             | -
| ComputerVision.clear | -           | -             | -              |  Clear computer vision path models.

## 🏗 Architectural Changes

Remove methods related with "Computer Vision" and create a module.
It is accessible like this: 
* `cameraView.ComputerVision.enable`
* `cameraView.ComputerVision.modelPaths`
* `cameraView.ComputerVision.clear`